### PR TITLE
Small fixes to make rc_genicam_driver work on latest Rolling.

### DIFF
--- a/src/genicam_driver.cpp
+++ b/src/genicam_driver.cpp
@@ -842,7 +842,7 @@ void GenICamDriver::triggerDepthAcquisition(
       res->return_code.message =
         "Triggering stereo matching is only possible if depth_acquisition_mode is set to SingleFrame "
         "or SingleFrameOut1!";
-      RCLCPP_DEBUG(this->get_logger(), res->return_code.message);
+      RCLCPP_DEBUG(this->get_logger(), "%s", res->return_code.message.c_str());
     }
   } else {
     res->return_code.value = rc_common_msgs::msg::ReturnCodeConstants::NOT_APPLICABLE;

--- a/src/publishers/confidence_publisher.hpp
+++ b/src/publishers/confidence_publisher.hpp
@@ -37,7 +37,7 @@
 #include "genicam2ros_publisher.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 namespace rc

--- a/src/publishers/depth_publisher.hpp
+++ b/src/publishers/depth_publisher.hpp
@@ -37,7 +37,7 @@
 #include "genicam2ros_publisher.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 namespace rc

--- a/src/publishers/disparity_color_publisher.hpp
+++ b/src/publishers/disparity_color_publisher.hpp
@@ -37,7 +37,7 @@
 #include "genicam2ros_publisher.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 namespace rc

--- a/src/publishers/error_depth_publisher.hpp
+++ b/src/publishers/error_depth_publisher.hpp
@@ -37,7 +37,7 @@
 #include "genicam2ros_publisher.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include <rc_genicam_api/imagelist.h>

--- a/src/publishers/error_disparity_publisher.hpp
+++ b/src/publishers/error_disparity_publisher.hpp
@@ -37,7 +37,7 @@
 #include "genicam2ros_publisher.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 #include <rc_genicam_api/imagelist.h>

--- a/src/publishers/image_publisher.hpp
+++ b/src/publishers/image_publisher.hpp
@@ -37,7 +37,7 @@
 #include "genicam2ros_publisher.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 
 namespace rc


### PR DESCRIPTION
In particular:

1.  Use image_transport.hpp to get rid of a warning
2.  Use C-strings for RCLCPP_ macros.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

After this PR, I can compile successfully against Rolling.