### PR TITLE
fix: parameter 'camera_wb_red' cannot be set

### DIFF
--- a/src/genicam_driver.cpp
+++ b/src/genicam_driver.cpp
@@ -1131,12 +1131,12 @@ void GenICamDriver::process()
 
               if (rcg::setEnum(nodemap, "BalanceRatioSelector", "Red", false)) {
                 double ratio = rcg::getFloat(nodemap, "BalanceRatio", 0, 0, true, true);
-                set_parameter(rclcpp::Parameter("camera_wb_red", ratio));
+                set_parameter(rclcpp::Parameter("camera_wb_ratio_red", ratio));
               }
 
               if (rcg::setEnum(nodemap, "BalanceRatioSelector", "Blue", false)) {
                 double ratio = rcg::getFloat(nodemap, "BalanceRatio", 0, 0, true, true);
-                set_parameter(rclcpp::Parameter("camera_wb_blue", ratio));
+                set_parameter(rclcpp::Parameter("camera_wb_ratio_blue", ratio));
               }
             }
 


### PR DESCRIPTION
Fixes wrong naming of two camera parameters which caused the driver to crash with error for color cameras:

```
./rc_genicam_driver 
[INFO] [1701701004.566275110] [genicam_driver]: Initializing
[INFO] [1701701004.566460410] [genicam_driver]: Processing thread started
[INFO] [1701701004.566502296] [genicam_driver]: Configuring
[INFO] [1701701007.695882081] [genicam_driver]: Connecting to sensor '<REDACTED>' alias rc_visard 160c
[INFO] [1701701010.121517660] [genicam_driver]: Start streaming images
[ERROR] [1701701010.773342531] [genicam_driver]: parameter 'camera_wb_red' cannot be set because it was not declared
[INFO] [1701701013.773845873] [genicam_driver]: Cleanup
```